### PR TITLE
fixing the failing tests

### DIFF
--- a/lib/Gedcom/Record.pm
+++ b/lib/Gedcom/Record.pm
@@ -565,6 +565,10 @@ sub normalise_dates
       my @dates = split / or /, $self->{value};
       for my $dt (@dates)
       {
+        #don't change the date if it looks like 'AFT 1989'
+        #AFT means AFTER and ParseDate returns the current date and the tests are failing
+        #current date can symbolize such an "after" date, but can also symbolize a very specific point in time and that could also confuse the user
+        next if $dt =~ m/^AFT/;
         # don't change the date if it is just < 7 digits
         if ($dt !~ /^\s*(\d+)\s*$/ || length $1 > 6)
         {


### PR DESCRIPTION
The tests are failing when Date::Manip is installed. 
The reason is that there are dates in the Gedcom file which look like this 

> AFT    1989

AFT comes from _after_
ParseDate() returns the current day when it parses those dates so that the roundtrip orig_date->parsed_date->orig_date ends with a different orig_date and the tests are failing.

The fix consists skipping from parsing those dates