### PR TITLE
WebServices.pm $VERSION wrong

### DIFF
--- a/lib/Gedcom/WebServices.pm
+++ b/lib/Gedcom/WebServices.pm
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 
 our $AUTOLOAD;
-our $VERSION = "1.15";
+our $VERSION = "1.19";
 
 package Gedcom::WebServices;
 

--- a/utils/makeh
+++ b/utils/makeh
@@ -16,7 +16,7 @@ my $Command = {
         local ($^I, @ARGV) = (".bak", @files);
         while (<>)
         {
-            s/(^\s*\$VERSION = ")\d+\.\d+(";)/$1$version$2/;
+            s/(^\s*(?:our\s+)?\$VERSION = ")\d+\.\d+(";)/$1$version$2/;
             s/(Version )\d+\.\d+( - ).*/$1$version$2$date/;
             s/(^\s*use Gedcom(?:::\w+)*\s+)\d+\.\d+;/$1$version;/;
             print;


### PR DESCRIPTION
utils/makeh did not expect "our $VERSION = ..." and did not update
WebServices.pm version - it had 1.15 instead of 1.19.

Fixed makeh and WebServices.pm