### PR TITLE
Fix For "->write() w/ $flush = 1" Bug

### DIFF
--- a/lib/Gedcom/Item.pm
+++ b/lib/Gedcom/Item.pm
@@ -389,7 +389,7 @@ sub write {
     my ($fh, $level, $flush) = @_;
     $level ||= 0;
     my @p;
-    push @p, $level . "  " x $level         unless $flush || $level < 0;
+    push @p, $level . "  " x ($flush ? 0 : $level) unless $level < 0;
     push @p, "\@$self->{xref}\@"            if     defined $self->{xref} &&
                                                    length $self->{xref};
     push @p, $self->{tag}                   if     $level >= 0;

--- a/t/Basic.pm
+++ b/t/Basic.pm
@@ -89,6 +89,7 @@ sub import {
         my $resolve     = $args{resolve};
         my $gedcom_file = $args{gedcom_file};
         my $read_only   = $args{read_only};
+        my $flush       = $args{flush} || 0;
 
         ok $ged;
         validate_ok($ged, $read_only);
@@ -286,11 +287,13 @@ sub import {
 
 
         my $f1 = $gedcom_file . $$;
-        $ged->write($f1);
+        $ged->write($f1, $flush);
         validate_ok($ged, $read_only);
         ok -e $f1;
 
         # check the gedcom file is correct
+        map { s/^(\d+)\s+/$1 / } @Ged_data if $flush;
+
         ok open F1, $f1;
         ok scalar <F1>, $_ for @Ged_data;
         ok eof;

--- a/t/flush.t
+++ b/t/flush.t
@@ -1,0 +1,16 @@
+#!/usr/local/bin/perl -w
+
+# Copyright 1998-2017, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# http://www.pjcj.net
+
+# Version 1.20 - 17th September 2016
+
+use strict;
+
+use lib -d "t" ? "t" : "..";
+
+use Basic (resolve => "unresolve_xrefs", flush => 1);


### PR DESCRIPTION
Calling `$ged->write("output.ged", 1)` produces an invalid Gedcom file — i.e., it doen't include the number at the beginning of each line — meaning Gedcom.pm can't read what it has written:

```
HEAD
SOUR PAF 2.2
VERS 2.2
DEST PAF
DATE Friday, 20th November 1992
FILE ROYALS.GED
```

This PR fixes that.